### PR TITLE
Various code edits for the manuscript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,5 @@
 *.pdf
 *.asv
 /.quarto/
-
+tables
 **/*.quarto_ipynb

--- a/R/analysis_1_variance_partitioning.qmd
+++ b/R/analysis_1_variance_partitioning.qmd
@@ -121,30 +121,6 @@ partitioning_all <- bind_rows(
 )
 ```
 
-Make barplots of these
-
-```{r}
-barplot_none <- make_barplot(partitioning_none) +
-  ggtitle(label = "No demographic variables")
-barplot_age <- make_barplot(partitioning_age) +
-  ggtitle(label = "Only age variable")
-barplot_all <- make_barplot(partitioning_all) +
-  ggtitle(label = "All demographic variables")
-
-varpart <- barplot_age +
-  ggtitle(
-    label = "Partitioning variance in daily log contact rates"
-  )
-ggsave("figures/varpart_age.png",
-       plot = varpart,
-       bg = "white",
-       scale = 1,
-       width = 6,
-       height = 4)
-```
-
-![](../figures/varpart_age.png)
-
 Arrange them in a multipanel figure, for supplemental materials
 
 ```{r}
@@ -184,7 +160,7 @@ ggsave("figures/varpart_all.png",
        plot = varpart_all,
        bg = "white",
        scale = 1,
-       width = 11,
+       width = 9,
        height = 6)
 ```
 

--- a/R/analysis_1_variance_partitioning.qmd
+++ b/R/analysis_1_variance_partitioning.qmd
@@ -8,14 +8,6 @@ editor: visual
 
 How much variation in contact rates are we missing?
 
-\- Demonstrate from contact surveys with repeat measures that age & occupation do not capture much of the variation between individuals in average contact rates
-
-See variation_partitioning.R for mostly complete code
-
-Move code here
-
-NEED: Publication-quality single-panel figure of variance partitioning for different surveys
-
 #### Analyse partitioning of variation in contact rates (within/between individuals and strata)
 
 Load packages and functions
@@ -25,61 +17,85 @@ Load packages and functions
 #| warning: false
 source("R/packages.R")
 source("R/functions.R")
+
+# set the RNG seed - used by the permutation check below
+set.seed(2026-07-07)
 ```
 
-Load the processed French Connection and Hong Kong data
+Load the processed French Connection and Hong Kong data. We add an observation identifier `obs` (one level per participant/wave/day) so that we can fit an observation-level random effect (see below).
 
 ```{r}
-fc_contact_counts <- process_fc_data_varpart()
-hk_contact_counts <- process_hk_data_varpart()
+fc_contact_counts <- process_fc_data_varpart() |>
+  mutate(obs = factor(row_number()))
+hk_contact_counts <- process_hk_data_varpart() |>
+  mutate(obs = factor(row_number()))
 ```
 
-Analyse this with a random effects model to capture the within-individual variation, the between-individual variation explained by age, and the residual between-individual variation
+We model the daily contact counts as Poisson with a log link (consistent with the other analyses in this repo). The random effects capture the within-individual variation (between observed days), the between-individual variation explained by age, and the residual between-individual variation.
 
-Gaussian random effects model, with only age, and between vs within individual effects
+A Poisson-log GLMM has no residual variance parameter: the day-to-day variation within an individual is otherwise assumed to be exactly Poisson sampling noise. Contact counts are overdispersed, so we add an **observation-level random effect** `(1|obs)` to capture genuine within-individual, extra-Poisson variation. Without it, that overdispersion would inflate the between-individual (`part_id`) variance. We fit with `nAGQ = 0` for numerical robustness, consistent with the two-stage model in analysis 3.
+
+First we fit for the France data.
 
 ```{r}
-fc_model_lmer_none <- lmer(
-  log1p(contacts) ~ (1|part_id),
-  data = fc_contact_counts
+#| message: false
+#| warning: false
+
+fc_model_none <- glmer(
+  contacts ~ (1|part_id) + (1|obs),
+  family = poisson,
+  data = fc_contact_counts,
+  nAGQ = 0
 )
 
-fc_model_lmer_age <- lmer(
-  log1p(contacts) ~ (1|part_age) +
-    (1|part_id),
-  data = fc_contact_counts
+fc_model_age <- glmer(
+  contacts ~ (1|part_age) +
+    (1|part_id) + (1|obs),
+  family = poisson,
+  data = fc_contact_counts,
+  nAGQ = 0
 )
 
 # the same but with gender and occupation (confounded)
-fc_model_lmer_all <- lmer(
-  log1p(contacts) ~ (1|part_age) +
+fc_model_all <- glmer(
+  contacts ~ (1|part_age) +
     (1|part_gender) +
     (1|part_occupation) +
-    (1|part_id),
-  data = fc_contact_counts
+    (1|part_id) + (1|obs),
+  family = poisson,
+  data = fc_contact_counts,
+  nAGQ = 0
 )
 ```
 
 Now for Hong Kong
 
 ```{r}
-hk_model_lmer_none <- lmer(
-  log1p(contacts) ~ (1|part_id),
-  data = hk_contact_counts
+#| message: false
+#| warning: false
+hk_model_none <- glmer(
+  contacts ~ (1|part_id) + (1|obs),
+  family = poisson,
+  data = hk_contact_counts,
+  nAGQ = 0
 )
 
-hk_model_lmer_age <- lmer(
-  log1p(contacts) ~ (1|part_age) +
-    (1|part_id),
-  data = hk_contact_counts
+hk_model_age <- glmer(
+  contacts ~ (1|part_age) +
+    (1|part_id) + (1|obs),
+  family = poisson,
+  data = hk_contact_counts,
+  nAGQ = 0
 )
 
 # the same but with gender (confounded)
-hk_model_lmer_all <- lmer(
-  log1p(contacts) ~ (1|part_age) +
+hk_model_all <- glmer(
+  contacts ~ (1|part_age) +
     (1|part_gender) +
-    (1|part_id),
-  data = hk_contact_counts
+    (1|part_id) + (1|obs),
+  family = poisson,
+  data = hk_contact_counts,
+  nAGQ = 0
 )
 ```
 
@@ -87,20 +103,20 @@ Do variance partitioning on each, combining across studies
 
 ```{r}
 partitioning_none <- bind_rows(
-  France = partition_variance_lmer(fc_model_lmer_none),
-  `Hong Kong` = partition_variance_lmer(hk_model_lmer_none),
+  France = partition_variance_glmer(fc_model_none),
+  `Hong Kong` = partition_variance_glmer(hk_model_none),
   .id = "Study"
 )
 
 partitioning_age <- bind_rows(
-  France = partition_variance_lmer(fc_model_lmer_age),
-  `Hong Kong` = partition_variance_lmer(hk_model_lmer_age),
+  France = partition_variance_glmer(fc_model_age),
+  `Hong Kong` = partition_variance_glmer(hk_model_age),
   .id = "Study"
 )
 
 partitioning_all <- bind_rows(
-  France = partition_variance_lmer(fc_model_lmer_all),
-  `Hong Kong` = partition_variance_lmer(hk_model_lmer_all),
+  France = partition_variance_glmer(fc_model_all),
+  `Hong Kong` = partition_variance_glmer(hk_model_all),
   .id = "Study"
 )
 ```
@@ -117,7 +133,7 @@ barplot_all <- make_barplot(partitioning_all) +
 
 varpart <- barplot_age +
   ggtitle(
-    label = "Partitioning variance in daily (log1p) contact rates"
+    label = "Partitioning variance in daily log contact rates"
   )
 ggsave("figures/varpart_age.png",
        plot = varpart,
@@ -132,15 +148,15 @@ ggsave("figures/varpart_age.png",
 Arrange them in a multipanel figure, for supplemental materials
 
 ```{r}
-varpart_all <- (barplot_none / barplot_age / barplot_all) +
-  plot_annotation(title = "Partitioning variance in daily (log1p) contact rates")
+varpart_all <- (barplot_none + barplot_age + barplot_all) +
+  plot_annotation(title = "Partitioning variance in daily log contact rates")
 
 ggsave("figures/varpart_all.png",
        plot = varpart_all,
        bg = "white",
        scale = 1,
-       width = 6,
-       height = 12)
+       width = 14,
+       height = 5)
 ```
 
 ![](../figures/varpart_all.png)
@@ -148,17 +164,21 @@ ggsave("figures/varpart_all.png",
 Sanity check this analysis by permuting the participant IDs - we would expect the proportion of variance within individuals (not explained by age/individual) to be high if we shuffled the data around between individuals/repeats. So confirm this.
 
 ```{r}
+#| message: false
+#| warning: false
 # sanity check contact variance analysis by permuting the participant IDs
 permute_sim <- function() {
   fc_contact_counts %>%
     mutate(
       contacts = sample(contacts)
     ) %>%
-    lmer(
-      log1p(contacts) ~ (1|part_age) + (1|part_id),
-      data = .
+    glmer(
+      contacts ~ (1|part_age) + (1|part_id) + (1|obs),
+      family = poisson,
+      data = .,
+      nAGQ = 0
     ) %>%
-    partition_variance_lmer() %>%
+    partition_variance_glmer() %>%
     select(-var) %>%
     pivot_wider(
       names_from = "partition",
@@ -166,6 +186,7 @@ permute_sim <- function() {
     )
 }
 
+set.seed(2026-07-07)
 sims_list <- replicate(50,
                        permute_sim(),
                   simplify = FALSE)
@@ -194,73 +215,20 @@ for (i in seq_along(partitions)) {
 }
 ```
 
-Alternatively, model age first, then add estimates as an offset
+Extract the between-individual standard deviation (`part_id`) from the age model. Because the model uses a log link, this is a standard deviation of individual log contact rates. This is comparable to the `sigma` of a lognormal individual activity distribution, as used in the full model. Though note that here we not account for heterogeneity in the contact ages when computing this parameter, so this is not intended as an estimate of `sigma` in that model.
 
 ```{r}
-fc_model_lmer_only_age <- lmer(
-  log1p(contacts) ~ (1|part_age),
-  data = fc_contact_counts
-)
-
-# using tidyverse pipes as R native pipes are cracking the shits at my abuse of infix notation
-age_offset_lookup <- fc_model_lmer_only_age %>%
-  coef %>%
-  `$`(part_age) %>%
-  tibble(
-    part_age = rownames(.),
-    offset = .[, 1]
-  ) %>%
-  select(-`(Intercept)`)
-
-fc_contact_counts_age_est <- fc_contact_counts |>
-  left_join(age_offset_lookup,
-            by = "part_age")
-
-fc_model_lmer_part_given_age <- lmer(
-  log1p(contacts) ~ (1|part_id) + offset(offset),
-  data = fc_contact_counts_age_est
-)
-
-fc_model_lmer_only_age
-# 0.2154 sd age
-# 0.6929 sd other
-fc_model_lmer_part_given_age
-# (of the other)
-# 0.4181 sd participant
-# 0.5478 participant
-```
-
-Compute variance partitions
-
-```{r}
-age_frac <- (0.2154^2) / (0.2154^2 + 0.6929^2)
-non_age_frac <- 1 - age_frac
-
-part_frac_of_other <- (0.4181^2) / (0.4181^2 + 0.5478^2)
-non_part_frac_of_other <- 1 - part_frac_of_other
-
-part_frac <- non_age_frac * part_frac_of_other
-within_frac <- non_age_frac * non_part_frac_of_other
-
-within_frac # 58%
-part_frac # 33%
-age_frac # 9%
-```
-
-Extract the sigma for these
-```{r}
-fc_sigma <- fc_model_lmer_age |>
+extract_part_id_sd <- function(model) {
+  model |>
     summary() |>
     extracting("varcor") |>
     as_tibble() |>
     filter(grp == "part_id") |>
-  select(sdcor)
-hk_sigma <- hk_model_lmer_age |>
-    summary() |>
-    extracting("varcor") |>
-    as_tibble() |>
-    filter(grp == "part_id") |>
-  select(sdcor)
+    pull(sdcor)
+}
+
+fc_sigma <- extract_part_id_sd(fc_model_age)
+hk_sigma <- extract_part_id_sd(hk_model_age)
 
 fc_sigma
 hk_sigma

--- a/R/analysis_1_variance_partitioning.qmd
+++ b/R/analysis_1_variance_partitioning.qmd
@@ -164,7 +164,72 @@ ggsave("figures/varpart_all.png",
        height = 6)
 ```
 
-![](../figures/varpart_all.png)
+Tabulate the same percentages (formatted as in the figure) for each model and study.
+
+```{r}
+component_levels <- c(
+  "within individuals",
+  "between individuals (unexplained)",
+  "between ages",
+  "between genders",
+  "between occupations"
+)
+model_levels <- c(
+  "No demographic variables",
+  "Only age variable",
+  "All demographic variables"
+)
+
+partitioning_all_models <- bind_rows(
+  `No demographic variables` = partitioning_none,
+  `Only age variable` = partitioning_age,
+  `All demographic variables` = partitioning_all,
+  .id = "Model"
+)
+
+# one row per study/model, one column per component, cells as formatted
+# percentages (a dash where a component is not in the model)
+partition_table <- function(data, levels) {
+  data |>
+    mutate(
+      Model = factor(Model, levels = model_levels),
+      partition = factor(partition, levels = levels),
+      percent = format_percent_label_1dp(proportion)
+    ) |>
+    select(Study, Model, partition, percent) |>
+    pivot_wider(
+      names_from = partition,
+      values_from = percent,
+      names_expand = TRUE
+    ) |>
+    arrange(Study, Model) |>
+    mutate(across(where(is.character), ~ replace_na(.x, "--")))
+}
+
+# write a human-readable text (markdown) version to tables/, and display it
+write_table_txt <- function(tab, caption, path) {
+  writeLines(c(caption, "", knitr::kable(tab, format = "pipe")), path)
+}
+
+caption_full <- "Variance in daily log contact rates (%), partitioned by component, for each model and study."
+partition_full <- partition_table(partitioning_all_models, component_levels)
+write_table_txt(partition_full, caption_full, "tables/variance_partition.txt")
+knitr::kable(partition_full, caption = caption_full)
+```
+
+The same partition after excluding the within-individual component, with the remaining (between-individual) components renormalised to sum to 100%.
+
+```{r}
+caption_between <- "Between-individual variance (%), partitioned among the age/gender/occupation and residual components (i.e. excluding within-individual variance and renormalising to 100%), for each model and study."
+partition_between <- partitioning_all_models |>
+  filter(partition != "within individuals") |>
+  group_by(Study, Model) |>
+  mutate(proportion = proportion / sum(proportion)) |>
+  ungroup() |>
+  partition_table(component_levels[-1])
+write_table_txt(partition_between, caption_between, "tables/variance_partition_excluding_within.txt")
+knitr::kable(partition_between, caption = caption_between)
+```
 
 Sanity check this analysis by permuting the participant IDs - we would expect the proportion of variance within individuals (not explained by age/individual) to be high if we shuffled the data around between individuals/repeats. So confirm this.
 

--- a/R/analysis_1_variance_partitioning.qmd
+++ b/R/analysis_1_variance_partitioning.qmd
@@ -125,11 +125,11 @@ Make barplots of these
 
 ```{r}
 barplot_none <- make_barplot(partitioning_none) +
-  ggtitle(label = "no covariates")
+  ggtitle(label = "No demographic variables")
 barplot_age <- make_barplot(partitioning_age) +
-  ggtitle(label = "age only")
+  ggtitle(label = "Only age variable")
 barplot_all <- make_barplot(partitioning_all) +
-  ggtitle(label = "additional predictors")
+  ggtitle(label = "All demographic variables")
 
 varpart <- barplot_age +
   ggtitle(
@@ -148,15 +148,44 @@ ggsave("figures/varpart_age.png",
 Arrange them in a multipanel figure, for supplemental materials
 
 ```{r}
-varpart_all <- (barplot_none + barplot_age + barplot_all) +
-  plot_annotation(title = "Partitioning variance in daily log contact rates")
+# panel C ("additional predictors") is the only panel containing all five
+# components, so let it carry the legend (its keys all have data and render
+# correctly); suppress the legend on A and B so a single, shared legend is
+# collected for the whole figure
+panel_age <- make_barplot(partitioning_age) +
+  ggtitle("Only age variable") +
+  theme(legend.position = "none")
+panel_none <- make_barplot(partitioning_none) +
+  ggtitle("No demographic variables") +
+  theme(legend.position = "none") +
+  # match the x-axis padding panel C gets from its leader-line labels, so the
+  # bars in panels B and C have the same width
+  scale_x_discrete(expand = expansion(add = 0.9))
+# raise the threshold so the (small) between-ages slice is labelled with a
+# leader line too, rather than crammed inside the bar next to between-genders
+panel_all <- make_barplot(partitioning_all, label_threshold = 0.07) +
+  ggtitle("All demographic variables")
+
+# panel A (age only) large on the left; B (no covariates) and C (all covariates)
+# stacked on the right
+design <- "
+AB
+AC
+"
+
+varpart_all <- panel_age + panel_none + panel_all +
+  plot_layout(design = design, guides = "collect") +
+  plot_annotation(
+    # title = "Partitioning variance in daily log contact rates",
+    tag_levels = "A"
+  )
 
 ggsave("figures/varpart_all.png",
        plot = varpart_all,
        bg = "white",
        scale = 1,
-       width = 14,
-       height = 5)
+       width = 11,
+       height = 6)
 ```
 
 ![](../figures/varpart_all.png)

--- a/R/analysis_3_real_world_application.qmd
+++ b/R/analysis_3_real_world_application.qmd
@@ -564,6 +564,41 @@ size_age_activity_by_age <- size_age_activity |>
     p_infected = sum(p_infected * activity_fractions))
 ```
 
+## Bootstrap uncertainty
+
+To quantify sampling uncertainty in these estimates we use a participant-level (cluster) bootstrap: we resample the survey participants with replacement (giving each drawn participant a fresh identifier, so a participant drawn more than once contributes as distinct individuals) and re-run the entire two-stage pipeline - age-structured contact model, residual heterogeneity `sigma`, activity matrix, R0s and final sizes - on each resample. The contact ages are re-imputed for each replicate, so imputation uncertainty is folded in as well.
+
+This is computationally expensive, so the bootstrap is run separately by `R/bootstrap_analysis_3.R` (which parallelises across cores and caches its output). Here we load the cached replicates and summarise them. We report **bias-corrected ("BC")** bootstrap intervals: percentile intervals adjusted for any median bias between the point estimate and the bootstrap distribution. The acceleration term of a full BCa interval is deferred - it needs either a separate jackknife or a jackknife-after-bootstrap from the stored resample membership, and is only worth adding if the bootstrap distributions turn out to be materially skewed (inspect `z0` in the summary table below).
+
+```{r}
+boot <- readRDS("data/boot_analysis_3.rds")
+
+# keep only the replicates that fitted successfully
+boot_ok <- boot$replicates |>
+  keep(~ is.null(.x$result$error))
+
+n_boot <- length(boot_ok)
+
+# tidy by-age final sizes across replicates (raw scenario keys)
+boot_by_age <- boot_ok |>
+  map_dfr(~ mutate(.x$result$by_age, rep = .x$rep))
+
+# tidy scalar quantities across replicates
+boot_scalars <- boot_ok |>
+  map_dfr(~ tibble(
+    rep = .x$rep,
+    sigma = .x$result$sigma,
+    R0_age = .x$result$R0_age,
+    R0_age_activity = .x$result$R0_age_activity,
+    overall_age = .x$result$overall[["age"]],
+    overall_age_scaled = .x$result$overall[["age_scaled"]],
+    overall_age_activity = .x$result$overall[["age_activity"]]
+  ))
+
+sprintf("%i of %i bootstrap replicates used (%i failed)",
+        n_boot, boot$config$B, boot$config$B - n_boot)
+```
+
 Plot these age distributions
 
 ```{r}
@@ -582,17 +617,34 @@ final_size_scenarios <- bind_rows(
   age          = size_age,
   age_scaled   = size_age_scaled,
   age_activity = size_age_activity_by_age,
-  .id = "scenario"
+  .id = "scenario_key"
 ) |>
   mutate(
     scenario = factor(
-      scenario_labels[scenario],
+      scenario_labels[scenario_key],
       levels = scenario_labels
     ),
     age_lower = as.numeric(str_match(demo_grp, "([0-9]+)[^0-9]+([0-9]+)")[, 2]),
     age_upper = as.numeric(str_match(demo_grp, "([0-9]+)[^0-9]+([0-9]+)")[, 3])
   ) |>
   arrange(scenario, age_lower)
+
+# bootstrap BC interval for each scenario x age bin, to draw as a band. The band
+# is piecewise-constant across each age bin (a geom_rect per bin), matching the
+# step lines exactly (a geom_ribbon would slope between bin midpoints instead).
+final_size_ci <- final_size_scenarios |>
+  select(scenario_key, scenario, age_lower, age_upper, p_infected) |>
+  pmap_dfr(function(scenario_key, scenario, age_lower, age_upper, p_infected) {
+    reps <- boot_by_age |>
+      filter(scenario == scenario_key, age_lower == !!age_lower) |>
+      pull(p_infected)
+    bc_ci(reps, p_infected) |>
+      mutate(
+        scenario = scenario,
+        age_lower = age_lower,
+        age_upper = age_upper
+      )
+  })
 
 # add a terminal point at the upper edge of the final bin for each scenario, so
 # the step spans the full width of every age bin (piecewise constant)
@@ -609,6 +661,13 @@ final_size_points <- final_size_scenarios |>
   mutate(age_mid = (age_lower + age_upper) / 2)
 
 final_size_plot <- ggplot() +
+  # 95% bootstrap BC interval, piecewise-constant across each age bin
+  geom_rect(
+    data = final_size_ci,
+    aes(xmin = age_lower, xmax = age_upper,
+        ymin = bc_lower, ymax = bc_upper, fill = scenario),
+    alpha = 0.2
+  ) +
   geom_step(
     data = final_size_steps,
     aes(x = age_lower, y = p_infected, colour = scenario),
@@ -616,13 +675,14 @@ final_size_plot <- ggplot() +
     linewidth = 0.8
   ) +
   scale_colour_brewer(palette = "Dark2") +
+  scale_fill_brewer(palette = "Dark2") +
+  guides(fill = "none") +
   scale_y_continuous(labels = scales::label_percent()) +
   coord_cartesian(ylim = c(0, 1)) +
   labs(
     x = "age",
     y = "final attack rate",
-    colour = "scenario",
-    shape = "scenario"
+    colour = "scenario"
   ) +
   theme_minimal()
 
@@ -636,13 +696,38 @@ ggsave("figures/final_size_by_age.png",
 final_size_plot
 ```
 
-Compute the overall final size from these bin-specific final sizes
+Compute the overall (population-weighted) final size from these bin-specific final sizes
 
 ```{r}
 overall_size_age <- sum(size_age$p_infected * age_fractions)
 overall_size_age_scaled <- sum(size_age_scaled$p_infected * age_fractions)
 overall_size_age_activity <- sum(size_age_activity$p_infected * age_activity_fractions)
-overall_size_age
-overall_size_age_scaled
-overall_size_age_activity
+```
+
+Finally, assemble the headline quantities with their point estimates and 95% bootstrap intervals. We show the bias-corrected ("BC") interval alongside the plain percentile interval, and the bias-correction constant `z0` (large `|z0|` would indicate the bootstrap distribution is noticeably off-centre from the point estimate, and hence that adding the BCa acceleration term might be worthwhile).
+
+```{r}
+summary_table <- bind_rows(
+  bc_ci(boot_scalars$R0_age, R0_age) |>
+    mutate(quantity = "R0 (age matrix)"),
+  bc_ci(boot_scalars$R0_age_activity, R0_age_activity) |>
+    mutate(quantity = "R0 (age/activity matrix)"),
+  bc_ci(boot_scalars$sigma, sigma_fc_twostage) |>
+    mutate(quantity = "residual heterogeneity (sigma)"),
+  bc_ci(boot_scalars$overall_age, overall_size_age) |>
+    mutate(quantity = "overall final size (age matrix)"),
+  bc_ci(boot_scalars$overall_age_scaled, overall_size_age_scaled) |>
+    mutate(quantity = "overall final size (age matrix, rescaled)"),
+  bc_ci(boot_scalars$overall_age_activity, overall_size_age_activity) |>
+    mutate(quantity = "overall final size (age/activity matrix)")
+) |>
+  transmute(
+    quantity,
+    estimate,
+    `BC 95% CI` = sprintf("(%.3f, %.3f)", bc_lower, bc_upper),
+    `percentile 95% CI` = sprintf("(%.3f, %.3f)", pct_lower, pct_upper),
+    z0 = round(z0, 2)
+  )
+
+knitr::kable(summary_table, digits = 3)
 ```

--- a/R/analysis_3_real_world_application.qmd
+++ b/R/analysis_3_real_world_application.qmd
@@ -27,6 +27,10 @@ Load packages and functions
 #| warning: false
 source("R/packages.R")
 source("R/functions.R")
+
+# set a seed for reproducibility, since contact ages are randomly imputed in
+# process_fc_data_conmat()
+set.seed(2026-07-06)
 ```
 
 Install the experimental `heterogeneous-augmentation` branch of conmat for simultaneous fitting of age effects and residual heterogeneity.
@@ -161,13 +165,17 @@ age_contact_pred_years <- fc_model_aggregated %>%
   )
 ```
 
-Next, add this to the participant level data.
+Next, add this to the participant level data. We truncate participant and contact ages at `max_age` (as elsewhere), since the age-structured contact model extrapolates poorly in the sparsely-observed oldest age groups: predicted contact rates there collapse to near zero, so an observed contact against a near-zero offset would otherwise create extreme leverage that destabilises the random effects model.
 
 ```{r}
 fc_contact_data_modelling <- fc_contact_data %>%
   left_join(
     age_contact_pred_years,
     by = c("age_from", "age_to")
+  ) %>%
+  filter(
+    age_from <= max_age,
+    age_to <= max_age
   )
 ```
 

--- a/R/analysis_3_real_world_application.qmd
+++ b/R/analysis_3_real_world_application.qmd
@@ -562,34 +562,73 @@ size_age_activity_by_age <- size_age_activity |>
 Plot these age distributions
 
 ```{r}
-plot_final_size_by_age <- function() {
-  plot(p_infected ~ factor(demo_grp),
-       type = "p",
-       pch = 16,
-       data = size_age_activity_by_age,
-       ylim = c(0, 1))
-  points(p_infected ~ factor(demo_grp),
-       pch = 16,
-       data = size_age,
-       col = "red")
-  points(p_infected ~ factor(demo_grp),
-       pch = 16,
-       data = size_age_scaled,
-       col = "blue")
-}
+# scenario labels, including the actual R0 each final size was computed under
+# (ordered as they should appear in the legend)
+scenario_labels <- c(
+  age          = sprintf("age matrix (R0 = %.2f)", R0_age),
+  age_activity = sprintf("age/activity matrix (R0 = %.2f)", R0_age_activity),
+  age_scaled   = sprintf("age matrix, rescaled (R0 = %.2f)", R0_age_activity)
+)
 
-# save to file
-png("figures/final_size_by_age.png",
-    width = 6,
-    height = 5,
-    units = "in",
-    res = 300,
-    bg = "white")
-plot_final_size_by_age()
-dev.off()
+# combine the three scenarios into one tibble, and parse the lower/upper edges
+# of each age bin from the group label (e.g. "[0,5)") so the bins can be placed
+# numerically on the x axis
+final_size_scenarios <- bind_rows(
+  age          = size_age,
+  age_scaled   = size_age_scaled,
+  age_activity = size_age_activity_by_age,
+  .id = "scenario"
+) |>
+  mutate(
+    scenario = factor(
+      scenario_labels[scenario],
+      levels = scenario_labels
+    ),
+    age_lower = as.numeric(str_match(demo_grp, "([0-9]+)[^0-9]+([0-9]+)")[, 2]),
+    age_upper = as.numeric(str_match(demo_grp, "([0-9]+)[^0-9]+([0-9]+)")[, 3])
+  ) |>
+  arrange(scenario, age_lower)
 
-# and render inline
-plot_final_size_by_age()
+# add a terminal point at the upper edge of the final bin for each scenario, so
+# the step spans the full width of every age bin (piecewise constant)
+final_size_steps <- final_size_scenarios |>
+  group_by(scenario) |>
+  group_modify(~ bind_rows(
+    .x,
+    mutate(slice_tail(.x, n = 1), age_lower = age_upper)
+  )) |>
+  ungroup()
+
+# points at the bin midpoints, to carry the per-scenario symbols
+final_size_points <- final_size_scenarios |>
+  mutate(age_mid = (age_lower + age_upper) / 2)
+
+final_size_plot <- ggplot() +
+  geom_step(
+    data = final_size_steps,
+    aes(x = age_lower, y = p_infected, colour = scenario),
+    direction = "hv",
+    linewidth = 0.8
+  ) +
+  scale_colour_brewer(palette = "Dark2") +
+  scale_y_continuous(labels = scales::label_percent()) +
+  coord_cartesian(ylim = c(0, 1)) +
+  labs(
+    x = "age",
+    y = "final attack rate",
+    colour = "scenario",
+    shape = "scenario"
+  ) +
+  theme_minimal()
+
+ggsave("figures/final_size_by_age.png",
+       plot = final_size_plot,
+       bg = "white",
+       width = 7,
+       height = 5,
+       dpi = 300)
+
+final_size_plot
 ```
 
 Compute the overall final size from these bin-specific final sizes

--- a/R/analysis_3_real_world_application.qmd
+++ b/R/analysis_3_real_world_application.qmd
@@ -182,12 +182,19 @@ fc_contact_data_modelling <- fc_contact_data %>%
 Finally, fit a Poisson GLMM and extract the estimate of sigma.
 
 ```{r}
-# fit the model
+# fit the model. We use nAGQ = 0 (optimising the random effects within the
+# PIRLS step rather than a separate adaptive Gauss-Hermite quadrature): the
+# default nAGQ = 1 Laplace fit is numerically unstable here - the many rare
+# age-pair observations with very small predicted offsets create high-leverage
+# points that intermittently break the PIRLS step ("Downdated VtV is not
+# positive definite"), depending on the random contact-age imputation. nAGQ = 0
+# is robust to this and gives an effectively identical variance estimate.
 model_twostage <- lme4::glmer(
   contacts ~ offset(log(predicted_contacts)) +
     (1|part_id),
   family = stats::poisson,
-  data = fc_contact_data_modelling
+  data = fc_contact_data_modelling,
+  nAGQ = 0
 )
 ```
 

--- a/R/analysis_3_real_world_application.qmd
+++ b/R/analysis_3_real_world_application.qmd
@@ -88,7 +88,14 @@ age_contact_pred <- predict_contacts(fc_model_aggregated,
                                      age_breaks = age_breaks)
 
 age_matrix <- conmat::predictions_to_matrix(age_contact_pred)
-autoplot(age_matrix)
+age_matrix_plot <- autoplot(age_matrix)
+ggsave("figures/fc_age_matrix.png",
+       plot = age_matrix_plot,
+       bg = "white",
+       width = 6,
+       height = 5,
+       dpi = 300)
+age_matrix_plot
 ```
 
 This is the type of standard analysis we would use to estimate an age-structured contact matrix. Now we wish to estimate the amount of contact heterogeneity in the survey data that is not explained by this-structured contact matrix, parameterised by the residual standard deviation of (log-)contacts.
@@ -303,7 +310,14 @@ age_matrix_participant <- fc_model_participant_lores |>
   predictions_to_matrix()
 
 # output the discretised age matrix
-autoplot(age_matrix_participant)
+age_matrix_participant_plot <- autoplot(age_matrix_participant)
+ggsave("figures/fc_age_matrix_participant.png",
+       plot = age_matrix_participant_plot,
+       bg = "white",
+       width = 6,
+       height = 5,
+       dpi = 300)
+age_matrix_participant_plot
 ```
 
 And finally, we can extract the standard deviation of the participant random effect.
@@ -370,6 +384,12 @@ We can visuliase this
 ```{r}
 activity_mat_plot <- autoplot_contact_matrix(activity_matrix, palette = 2) +
   ggtitle("activity-structured")
+ggsave("figures/activity_structured_matrix.png",
+       plot = activity_mat_plot,
+       bg = "white",
+       width = 6,
+       height = 5,
+       dpi = 300)
 activity_mat_plot
 ```
 
@@ -408,6 +428,12 @@ age_contact_pred <- predict_contacts(fc_model_aggregated,
 age_matrix <- conmat::predictions_to_matrix(age_contact_pred)
 age_mat_plot <- autoplot_contact_matrix(age_matrix, palette = 1) +
   ggtitle("age-structured")
+ggsave("figures/age_structured_matrix.png",
+       plot = age_mat_plot,
+       bg = "white",
+       width = 6,
+       height = 5,
+       dpi = 300)
 age_mat_plot
 ```
 
@@ -422,8 +448,14 @@ We can visualise these together
 ```{r}
 age_activity_mat_plot <- autoplot_contact_matrix(age_activity_matrix, palette = 7) +
   ggtitle("age/activity-structured")
+ggsave("figures/age_activity_structured_matrix.png",
+       plot = age_activity_mat_plot,
+       bg = "white",
+       width = 6,
+       height = 5,
+       dpi = 300)
 age_activity_mat_plot
-  
+
 ```
 
 Next we recompute these matrices for a predetermined set of 5 year age bins, and a more optimal configuration of activity bins, and investigate the implications for analyses of disease transmission.
@@ -522,19 +554,34 @@ size_age_activity_by_age <- size_age_activity |>
 Plot these age distributions
 
 ```{r}
-plot(p_infected ~ factor(demo_grp),
-     type = "p",
-     pch = 16,
-     data = size_age_activity_by_age,
-     ylim = c(0, 1))
-points(p_infected ~ factor(demo_grp),
-     pch = 16,
-     data = size_age,
-     col = "red")
-points(p_infected ~ factor(demo_grp),
-     pch = 16,
-     data = size_age_scaled,
-     col = "blue")
+plot_final_size_by_age <- function() {
+  plot(p_infected ~ factor(demo_grp),
+       type = "p",
+       pch = 16,
+       data = size_age_activity_by_age,
+       ylim = c(0, 1))
+  points(p_infected ~ factor(demo_grp),
+       pch = 16,
+       data = size_age,
+       col = "red")
+  points(p_infected ~ factor(demo_grp),
+       pch = 16,
+       data = size_age_scaled,
+       col = "blue")
+}
+
+# save to file
+png("figures/final_size_by_age.png",
+    width = 6,
+    height = 5,
+    units = "in",
+    res = 300,
+    bg = "white")
+plot_final_size_by_age()
+dev.off()
+
+# and render inline
+plot_final_size_by_age()
 ```
 
 Compute the overall final size from these bin-specific final sizes

--- a/R/analysis_3_real_world_application.qmd
+++ b/R/analysis_3_real_world_application.qmd
@@ -392,12 +392,6 @@ We can visuliase this
 ```{r}
 activity_mat_plot <- autoplot_contact_matrix(activity_matrix, palette = 2) +
   ggtitle("activity-structured")
-ggsave("figures/activity_structured_matrix.png",
-       plot = activity_mat_plot,
-       bg = "white",
-       width = 6,
-       height = 5,
-       dpi = 300)
 activity_mat_plot
 ```
 
@@ -436,12 +430,6 @@ age_contact_pred <- predict_contacts(fc_model_aggregated,
 age_matrix <- conmat::predictions_to_matrix(age_contact_pred)
 age_mat_plot <- autoplot_contact_matrix(age_matrix, palette = 1) +
   ggtitle("age-structured")
-ggsave("figures/age_structured_matrix.png",
-       plot = age_mat_plot,
-       bg = "white",
-       width = 6,
-       height = 5,
-       dpi = 300)
 age_mat_plot
 ```
 
@@ -456,14 +444,24 @@ We can visualise these together
 ```{r}
 age_activity_mat_plot <- autoplot_contact_matrix(age_activity_matrix, palette = 7) +
   ggtitle("age/activity-structured")
-ggsave("figures/age_activity_structured_matrix.png",
-       plot = age_activity_mat_plot,
-       bg = "white",
-       width = 6,
-       height = 5,
-       dpi = 300)
 age_activity_mat_plot
 
+```
+
+Finally, combine the three illustrative matrices into a single three-panel figure (age-structured, activity-structured, age/activity-structured) for the manuscript.
+
+```{r}
+illustrative_matrices_plot <- age_mat_plot +
+  activity_mat_plot +
+  age_activity_mat_plot +
+  plot_layout(nrow = 1)
+ggsave("figures/illustrative_contact_matrices.png",
+       plot = illustrative_matrices_plot,
+       bg = "white",
+       width = 15,
+       height = 5,
+       dpi = 300)
+illustrative_matrices_plot
 ```
 
 Next we recompute these matrices for a predetermined set of 5 year age bins, and a more optimal configuration of activity bins, and investigate the implications for analyses of disease transmission.

--- a/R/analysis_s1_binning_methods.qmd
+++ b/R/analysis_s1_binning_methods.qmd
@@ -97,7 +97,6 @@ p_gq <- ggplot(gq_classes,
   theme_minimal()
 
 binning_illustration <- p_target / p_quantile / p_gq
-binning_illustration
 
 ggsave("figures/binning_illustration.png",
        plot = binning_illustration,
@@ -113,14 +112,13 @@ The Gaussian quadrature scheme is able to place bins much further into the two t
 
 #### Approximating the distribution
 
-First we assess the ability of the binning scheme to approximate the first two moments of the distribution, by computing numerical approximations to these parameters based on the binning schemes, and comparing them to the truth, for known values of sigma.
+Next we assess the ability of each binning scheme to approximate the first two moments of the true distribution, by computing numerical approximations to these mean and variance of the distribution over activity levels using each of the binning schemes as a quadrature scheme. We vary the number of bins or each scheme and compare the approximations to the mean and variance against the truth, for three values of sigma.
 
 ```{r}
 estimates <- expand_grid(
   n_classes = 2:20,
   sigma = c(0.5, 1, 2),
   method = c("truth",
-             "quantile_mean",
              "gaussquad",
              "quantile2_mean")
 ) |>
@@ -138,18 +136,63 @@ estimates <- expand_grid(
                                  n_classes,
                                  method = method)
     )
+  ) |>
+  ungroup() |>
+  # relabel methods for display (quantile2_mean is the deterministic
+  # numerical-integration version of the quantile mean method)
+  mutate(
+    method = recode(
+      method,
+      quantile2_mean = "quantile mean",
+      gaussquad = "Gaussian quadrature"
+    )
   )
 
 ```
 
 Plot these
+
 ```{r}
-estimates |>
+# colour used for the Gaussian quadrature line (first of the two default hues)
+gq_colour <- scales::hue_pal()(2)[1]
+
+moment_long <- estimates |>
   pivot_longer(
     cols = c("mean", "sd"),
     values_to = "estimate",
     names_to = "moment"
+  )
+
+# smallest number of bins for which the Gaussian quadrature estimate is within
+# 1% of the true value, for each moment and value of sigma
+moment_threshold <- moment_long |>
+  filter(method == "Gaussian quadrature") |>
+  left_join(
+    moment_long |>
+      filter(method == "truth") |>
+      select(n_classes, sigma, moment, true = estimate),
+    by = c("n_classes", "sigma", "moment")
   ) |>
+  filter(abs(estimate - true) / true < 0.01) |>
+  group_by(moment, sigma) |>
+  summarise(
+    bins_1pct = min(n_classes),
+    .groups = "drop"
+  ) |>
+  mutate(
+    sigma = paste("sigma: ", sigma)
+  )
+
+# the true value of each moment, for each sigma
+moment_truth <- moment_long |>
+  filter(method == "truth") |>
+  distinct(moment, sigma, true = estimate) |>
+  mutate(
+    sigma = paste("sigma: ", sigma)
+  )
+
+moment_convergence <- moment_long |>
+  filter(method != "truth") |>
   mutate(
     sigma = paste("sigma: ", sigma)
   ) |>
@@ -160,52 +203,143 @@ estimates |>
       colour = method,
     )
   ) +
-  geom_line() +
+  geom_hline(
+    aes(yintercept = true),
+    data = moment_truth,
+    linetype = 2,
+    linewidth = 0.8
+  ) +
+  geom_text(
+    aes(
+      y = true,
+      label = "true value"
+    ),
+    data = moment_truth,
+    x = -Inf,
+    hjust = -0.05,
+    vjust = -0.6,
+    size = 3,
+    colour = "black",
+    inherit.aes = FALSE
+  ) +
+  geom_vline(
+    aes(xintercept = bins_1pct),
+    data = moment_threshold,
+    linetype = 3,
+    linewidth = 0.8,
+    colour = gq_colour
+  ) +
+  geom_text(
+    aes(
+      x = bins_1pct,
+      label = paste0(bins_1pct, " bins, <1% error")
+    ),
+    data = moment_threshold,
+    y = -Inf,
+    hjust = -0.1,
+    vjust = -0.8,
+    size = 3,
+    colour = gq_colour,
+    inherit.aes = FALSE
+  ) +
+  xlab("number of bins") +
+  geom_line(
+    linewidth = 1
+  ) +
   facet_wrap(
     moment ~ sigma,
     scales = "free_y"
   ) +
-  theme_minimal()
+  scale_y_continuous(
+    expand = expansion(mult = c(0.05, 0.12))
+  ) +
+  theme_minimal() +
+  theme(legend.position = "bottom")
+
+ggsave("figures/binning_moment_convergence.png",
+       plot = moment_convergence,
+       bg = "white",
+       scale = 1,
+       width = 8,
+       height = 5)
 
 ```
-Perhaps unsurprisingly, Gaussian quadrature converges rapidly and consistently at this task. K-means appears to converge rapidly, but is quite stochastic (due to the random sampling used to fit the clustering model), with the other methods generally converging more slowly, especially for the standard deviation. The quantile median consistently understimates the standard deviation even with 20 bins.
+
+![](../figures/binning_moment_convergence.png)
+
+The quantile mean scheme approximates the mean well regardless of the number of bins, but converges very slowly to the true estimate of the variance, as the number of bins increases. By contrast, the Gaussian quadrature scheme converges rapidly and consistently to both the mean and standard deviation at this task. Even with a very large sigma (\$\\sigma=2\$ corresponds to a standard deviation of over a 50-fold difference in contact rates compared with log-mean), the Gaussian quadrature scheme is able to accurately approximate the standard deviation (to within 1% of the true value) with only 11 bins. By comparison, the quantile mean scheme significantly understimates the standard deviation (by a factor of more than 2) even with double the number of bins.
 
 #### Approximating the eigenvalue
 
-While the above analysis is a fairly straightforward assessment of the ability of these schemes to integrate the distribution, the main task is to accurately estimate the eigenvalue of matrix constructed from this distribution. Given the strong influence of the upper tail of the activity distribution on the eigenvalue, the results of this analysis are likely to be quite different.
-
-Approximate the eigenvalue for different numbers of bins for the different methods.
+Finally, we asses the ability of each binning scheme to accurately estimate the eigenvalue of an activity-only contact matrix constructed from this distribution, again for the same three values of sigma. Here we display the true eigenvalue as a horizontal dashed line.
 
 ```{r}
 plan(multisession, workers = 8)
-sigma <- 1
 
 eigenvalue_convergence <- expand_grid(
-  bins = seq(2, 100, by = 1),
-  method = c("quantile_mean",
-             "gaussquad",
+  bins = seq(2, 20, by = 1),
+  sigma = c(0.5, 1, 2),
+  method = c("gaussquad",
              "quantile2_mean")
 ) |>
   mutate(
-    eigenvalue = furrr::future_map2(
-      bins,
-      method,
-      ~ map_to_eigen(n_classes = .x,
-                     sigma = sigma,
-                     method = .y,
-                     assort = 0),
+    eigenvalue = furrr::future_pmap(
+      list(bins, sigma, method),
+      \(bins, sigma, method) map_to_eigen(n_classes = bins,
+                                          sigma = sigma,
+                                          method = method,
+                                          assort = 0),
       .options = furrr_options(seed = TRUE)
+    )
+  ) |>
+  # relabel methods for display (quantile2_mean is the deterministic
+  # numerical-integration version of the quantile mean method)
+  mutate(
+    method = recode(
+      method,
+      quantile2_mean = "quantile mean",
+      gaussquad = "Gaussian quadrature"
     )
   )
 ```
 
-Plot convergence
 ```{r}
-# this is the true eigenvalue for the proportional mixing assumption
-true_eigenval <- exp(1.5 * sigma ^ 2)
-eigenvalue_convergence |>
+# the true eigenvalue for the proportional mixing assumption, for each sigma
+true_eigenval <- tibble(
+  sigma = c(0.5, 1, 2)
+) |>
+  mutate(
+    true = exp(1.5 * sigma ^ 2)
+  )
+
+eigenvalue_long <- eigenvalue_convergence |>
   unnest(
     eigenvalue
+  ) |>
+  left_join(
+    true_eigenval,
+    by = "sigma"
+  )
+
+# smallest number of bins for which the Gaussian quadrature estimate is
+# within 1% of the true eigenvalue, for each sigma
+convergence_threshold <- eigenvalue_long |>
+  filter(
+    method == "Gaussian quadrature",
+    abs(eigenvalue - true) / true < 0.01
+  ) |>
+  group_by(sigma) |>
+  summarise(
+    bins_1pct = min(bins),
+    .groups = "drop"
+  ) |>
+  mutate(
+    sigma = paste("sigma: ", sigma)
+  )
+
+eigenvalue_convergence_plot <- eigenvalue_long |>
+  mutate(
+    sigma = paste("sigma: ", sigma)
   ) |>
   ggplot(
     aes(
@@ -214,97 +348,69 @@ eigenvalue_convergence |>
       group = method,
       colour = method)
   ) +
-  geom_abline(
-    intercept = true_eigenval,
-    slope = 0,
-    linetype = 2
-  ) +
-  geom_line() +
-  xlab("Number of classes") +
-  theme_minimal()
-```
-
-#### Monte Carlo "true" eigenvalue reference
-
-To complement the analytical convergence curves above, we add a reference value computed directly from a large Monte Carlo sample (translation of `Matlab/matrix_bins.m`). We draw N = 10,000 individuals from a lognormal(0, sigma = 1) distribution, then compute the dominant eigenvalue of the full proportionate mixing matrix.
-
-In MATLAB this required forming and diagonalising a 10,000 × 10,000 matrix (~800 MB). In R we exploit the rank-1 structure of the proportionate mixing matrix: for `M = a aᵀ / sum(a)`, the eigenvector is `a` itself and the dominant eigenvalue is `sum(a²) / sum(a)`. This closed form is exact and requires no matrix materialisation.
-
-```{r}
-set.seed(2024)
-N <- 1e4
-
-activity_mc <- rlnorm(N, meanlog = 0, sdlog = sigma)
-
-# "True" MC eigenvalue: closed-form dominant eigenvalue of the rank-1
-# proportionate mixing matrix M = a a^T / sum(a)
-lambda_mc_true <- sum(activity_mc ^ 2) / sum(activity_mc)
-
-# Population-level analytic value (the MC estimate converges to this as N -> Inf)
-lambda_analytic <- exp(1.5 * sigma ^ 2)
-```
-
-Now compute the eigenvalue of binned approximations using quantile bins drawn from the MC sample, matching the MATLAB approach in `matrix_bins.m`.
-
-```{r}
-n_bins_range <- c(2:100, seq(200, 2000, by = 100))
-
-eigenvalue_convergence_mc <- tibble(n_bins = n_bins_range) |>
-  rowwise() |>
-  mutate(
-    eigenvalue = {
-      probs <- seq(0, 1, length.out = n_bins + 1)
-      bin_edges <- quantile(activity_mc, probs = probs)
-      bin_edges[1] <- 0
-
-      bin_means <- vapply(seq_len(n_bins), \(i) {
-        in_bin <- activity_mc > bin_edges[i] & activity_mc <= bin_edges[i + 1]
-        mean(activity_mc[in_bin])
-      }, numeric(1))
-
-      # Dominant eigenvalue of binned proportionate mixing matrix (rank-1 closed form)
-      sum(bin_means ^ 2) / sum(bin_means)
-    }
-  ) |>
-  ungroup()
-```
-
-Plot eigenvalue convergence with both MC and analytic reference lines.
-
-```{r}
-eigenvalue_convergence_mc |>
-  ggplot(
-    aes(x = n_bins, y = eigenvalue)
-  ) +
-  geom_line() +
-  geom_point(size = 0.5) +
   geom_hline(
-    yintercept = lambda_mc_true,
-    linetype = "dashed",
-    colour = "red"
+    aes(yintercept = true),
+    data = true_eigenval |> mutate(sigma = paste("sigma: ", sigma)),
+    linetype = 2,
+    linewidth = 0.8
   ) +
-  geom_hline(
-    yintercept = lambda_analytic,
-    linetype = "dotted",
-    colour = "blue"
+  geom_text(
+    aes(
+      y = true,
+      label = "true value"
+    ),
+    data = true_eigenval |> mutate(sigma = paste("sigma: ", sigma)),
+    x = -Inf,
+    hjust = -0.05,
+    vjust = -0.6,
+    size = 3,
+    colour = "black",
+    inherit.aes = FALSE
   ) +
-  annotate(
-    "text", x = 200, y = lambda_mc_true * 1.004,
-    label = '"true" MC value', colour = "red", hjust = 0
+  geom_vline(
+    aes(xintercept = bins_1pct),
+    data = convergence_threshold,
+    linetype = 3,
+    linewidth = 0.8,
+    colour = gq_colour
   ) +
-  annotate(
-    "text", x = 200, y = lambda_analytic * 0.997,
-    label = "population analytic", colour = "blue", hjust = 0
+  geom_text(
+    aes(
+      x = bins_1pct,
+      label = paste0(bins_1pct, " bins, <1% error")
+    ),
+    data = convergence_threshold,
+    y = -Inf,
+    hjust = -0.1,
+    vjust = -0.8,
+    size = 3,
+    colour = gq_colour,
+    inherit.aes = FALSE
   ) +
-  scale_x_log10() +
-  labs(
-    x = "number of bins",
-    y = "dominant eigenvalue",
-    title = sprintf(
-      "Eigenvalue convergence with MC-quantile binning (proportionate mixing, N = %d)", N
-    )
+  geom_line(
+    linewidth = 1
   ) +
-  theme_minimal()
+  facet_wrap(
+    ~ sigma,
+    nrow = 1,
+    scales = "free_y"
+  ) +
+  scale_y_continuous(
+    expand = expansion(mult = c(0.05, 0.12))
+  ) +
+  xlab("number of bins") +
+  ylab("dominant eigenvalue") +
+  theme_minimal() +
+  theme(legend.position = "bottom")
+
+ggsave("figures/binning_eigenvalue_convergence.png",
+       plot = eigenvalue_convergence_plot,
+       bg = "white",
+       scale = 1,
+       width = 9,
+       height = 4)
 ```
 
-The dashed red line is the finite-sample MC reference value; the dotted blue line is the population analytical value `exp(1.5 * sigma²)`. The binned eigenvalue converges to the MC reference, which itself fluctuates around the analytic value due to sampling variance from N = 10,000 draws.
+![](../figures/binning_eigenvalue_convergence.png)
+
+Across all values of \$\\sigma\$ we see that the Gaussian quadrature scheme converges on the true eigenvalue of the activity-only contact matrix far more quickly than the quantile mean. Even with the extreme \$\\sigma=2\$, 12 bins are sufficient to approximate the eigenvalue to within 1%. With \$\\sigma=0.5\$ (roughly matching the France and Hong Kong data), 3 bins are sufficient to achieve the same level of accuracy.

--- a/R/analysis_s1_binning_methods.qmd
+++ b/R/analysis_s1_binning_methods.qmd
@@ -6,32 +6,110 @@ editor: visual
 
 # Comparing alternative binning methods for summarising the activity level distribution
 
-The computational efficiency of our proposed method relies on the ability to represent the population distribution of activity levels in a comparatively low number of bins. Specifically, we aim to rapidly converge on the true eigenvalue for a population, as the number of bins increases.
+The computational efficiency of our proposed method relies on the ability to represent the population distribution of activity levels in a comparatively low number of bins. Specifically, we aim to rapidly converge on the true eigenvalue for a population, as the number of bins increases. We find that defining bin sizes and activity levels according to a Gaussian quadrature scheme achieves a good level of convergence, and outperforms using evenly-sized bins and setting the bin activity level to the bin mean.
 
-### Methods
+Here we illustrate the differences between these two alternative binning methods, both visually and in terms of representing the mean and variance of the distribution, and then demonstrate that the Gaussian quadrature scheme converges on the true eigenvalue considerably more quickly than the evenly-sized bins approach.
 
-This analysis compares a number of alternative methods:
+The two binning methods we consider are defined as follows
 
 #### Quantiles with mean activity
-Define bins by evenly-spaced quantiles and approximate the mean activity levels in each bin
+
+Define bins of equal population size by defining evenly-spaced quantiles of the distribution over activity levels (up to some maximum quantile) and set the activity level for each bin to its mean, computed by numerical integration via one dimensional adaptive quadrature over the activity range of the bin.
 
 #### Gaussian quadrature scheme
-Define bins according to the points of a Guassian quadrature scheme, with poulation fractions given by the normalised weights.
 
-#### Evenly-sized bins
-Defining bins of even size (i.e. range of activity levels between the upper and lower bound of the bin) up to the 99.9 percentile of the distribution, approximating the mean activity level (by numerical integration) and computing population fraction in each bin.
+Define bins of unequal size according to the nodes of a Guassian quadrature scheme, with activity levels given by the node locations, and population fractions given by the normalised weights.
 
-#### Hybrid scheme of quantiles and evenly-sized bins
-Defining around half the bins to be equal quantiles, up to the 90 percentile, and then the remaining bins to be evenly sized, from the 90 to the 99.9 percentiles, approximating the mean activity level (by numerical integration) and computing population fraction in each bin.
-
-### Evaluation
-
-```{r}
+```{r echo = FALSE}
 #| message: false
 #| warning: false
 source("R/packages.R")
 source("R/functions.R")
 ```
+
+#### Illustrating the binning schemes
+
+First, we illustrate how two of the binning schemes place their bins relative to the target distribution. For both schemes we use 7 bins and set \$\\sigma = 0.4\$. The top panel shows the target lognormal density of activity levels, corresponding to our model of activity. The middle and lower panels show the bin activity levels (points) and population fractions (vertical stems) for the quantile-mean and Gaussian quadrature schemes respectively.
+
+```{r}
+#| message: false
+#| warning: false
+sigma <- 0.4
+n_int <- 7
+
+# quantile mean and Gaussian quadrature classes
+quantile_classes <- quantile2_classes_mean(sigma = sigma,
+                                            n_classes = n_int)
+gq_classes <- gaussquad_classes(sigma = sigma,
+                                n_classes = n_int)
+
+# common x-axis range
+xmax <- max(
+  qlnorm(0.99, 0, sigma),
+  max(quantile_classes$activity),
+  max(gq_classes$activity)
+)
+
+# top panel: target distribution
+p_target <- ggplot() +
+  geom_function(
+    fun = dlnorm,
+    args = list(meanlog = 0, sdlog = sigma)
+  ) +
+  xlim(0, xmax) +
+  labs(
+    title = "Target distribution",
+    x = "activity level (v)",
+    y = "p(v)"
+  ) +
+  theme_minimal()
+
+# middle panel: quantile mean classes
+p_quantile <- ggplot(quantile_classes,
+                     aes(x = activity, y = fraction)) +
+  geom_segment(
+    aes(xend = activity, yend = 0)
+  ) +
+  geom_point(size = 2) +
+  xlim(0, xmax) +
+  ylim(0, max(quantile_classes$fraction) * 1.1) +
+  labs(
+    title = "Quantile mean",
+    x = "activity level (v)",
+    y = "population fraction"
+  ) +
+  theme_minimal()
+
+# lower panel: Gaussian quadrature classes
+p_gq <- ggplot(gq_classes,
+              aes(x = activity, y = fraction)) +
+  geom_segment(
+    aes(xend = activity, yend = 0)
+  ) +
+  geom_point(size = 2) +
+  xlim(0, xmax) +
+  ylim(0, max(gq_classes$fraction) * 1.1) +
+  labs(
+    title = "Gaussian quadrature",
+    x = "activity level (v)",
+    y = "population fraction"
+  ) +
+  theme_minimal()
+
+binning_illustration <- p_target / p_quantile / p_gq
+binning_illustration
+
+ggsave("figures/binning_illustration.png",
+       plot = binning_illustration,
+       bg = "white",
+       scale = 1,
+       width = 6,
+       height = 8)
+```
+
+![](../figures/binning_illustration.png)
+
+The Gaussian quadrature scheme is able to place bins much further into the two tails of the distribution than the quantile mean scheme. Whilst few individuals would have activity levels in these tails, those that do (particularly at the upper tail) contribute significantly to the population eigenvalue.
 
 #### Approximating the distribution
 

--- a/R/bootstrap_analysis_3.R
+++ b/R/bootstrap_analysis_3.R
@@ -1,0 +1,131 @@
+# Participant-level (cluster) bootstrap for the analysis-3 two-stage pipeline.
+#
+# Each replicate re-imputes the contact ages (a fresh call to
+# process_fc_data_conmat()), resamples the participants with replacement giving
+# each draw a fresh part_id, and re-runs the whole downstream pipeline
+# (age-structured contact model -> residual heterogeneity sigma -> activity
+# matrix -> R0s -> final sizes for the three scenarios). We store, per replicate,
+# the resulting quantities plus the participant membership (which participants
+# were drawn), so that a BCa acceleration term can be estimated later via
+# jackknife-after-bootstrap without re-running anything.
+#
+# This is expensive (~15 s / replicate; ~40 min for B = 1000 across 7 workers),
+# so it is kept out of the Quarto document: run this script once and the qmd
+# reads the cached results from data/boot_analysis_3.rds.
+#
+# Usage:  Rscript R/bootstrap_analysis_3.R [B]     (B defaults to 1000)
+
+suppressMessages({
+  source("R/packages.R")
+  source("R/functions.R")
+})
+
+# number of bootstrap replicates (override from the command line for testing)
+args <- commandArgs(trailingOnly = TRUE)
+B <- if (length(args) >= 1) as.integer(args[1]) else 1000L
+
+# fixed configuration, shared with the point-estimate analysis in the qmd
+beta <- 0.1
+alpha <- 0.5
+epsilon <- 0.5
+n_activity_bins <- 10
+max_age <- 90
+
+# population / demography is external census data, held fixed across bootstraps
+fc_population <- age_population(
+  data = socialmixr::wpp_age(),
+  location_col = country,
+  location = c("France"),
+  age_col = lower.age.limit,
+  year_col = year,
+  year = 2010
+)
+
+# canonical participant ordering, so membership indices are comparable across
+# replicates. The set of participants is fixed (imputation only changes contact
+# ages), so this can be established once.
+proc0 <- process_fc_data_conmat()
+canonical_ids <- as.character(unique(proc0$part_id))
+rm(proc0)
+
+# helper to load, re-impute and rename the participant-level data
+load_fc_participant_data <- function() {
+  process_fc_data_conmat() |>
+    rename(age_from = part_age, age_to = cont_age) |>
+    mutate(setting = "all", part_id = as.character(part_id))
+}
+
+# one bootstrap replicate: re-impute, resample participants, run the pipeline
+one_boot <- function(i) {
+  contact_data <- load_fc_participant_data()
+  resample <- resample_participants(contact_data, canonical_ids)
+  result <- tryCatch(
+    fc_final_size_pipeline(
+      resample$data,
+      population = fc_population,
+      beta = beta,
+      alpha = alpha,
+      epsilon = epsilon,
+      n_activity_bins = n_activity_bins,
+      max_age = max_age
+    ),
+    error = function(e) list(error = conditionMessage(e))
+  )
+  list(rep = i, membership = resample$membership, result = result)
+}
+
+# also compute the point estimate on the full (unresampled) data, so the doc's
+# central line and the BCa bias-correction use exactly the same estimator as the
+# replicates
+point_data <- load_fc_participant_data()
+point_estimate <- fc_final_size_pipeline(
+  point_data,
+  population = fc_population,
+  beta = beta,
+  alpha = alpha,
+  epsilon = epsilon,
+  n_activity_bins = n_activity_bins,
+  max_age = max_age
+)
+rm(point_data)
+
+# run the replicates in parallel, with parallel-safe RNG streams
+n_workers <- max(1, parallel::detectCores() - 1)
+plan(multisession, workers = n_workers)
+
+# date-mnemonic seed (see repo convention); with furrr_options(seed = TRUE) this
+# seeds reproducible independent L'Ecuyer streams for the workers
+set.seed(2026-07-06)
+
+message(sprintf("running %d bootstrap replicates on %d workers...", B, n_workers))
+boot_start <- Sys.time()
+
+replicates <- future_map(
+  seq_len(B),
+  one_boot,
+  .options = furrr_options(seed = TRUE),
+  .progress = TRUE
+)
+
+plan(sequential)
+boot_secs <- as.numeric(difftime(Sys.time(), boot_start, units = "secs"))
+
+# report how many replicates succeeded
+failed <- vapply(replicates,
+                 function(x) !is.null(x$result$error),
+                 logical(1))
+message(sprintf("done in %.1f min; %d / %d replicates succeeded (%d failed)",
+                boot_secs / 60, sum(!failed), B, sum(failed)))
+
+boot_results <- list(
+  point_estimate = point_estimate,
+  replicates = replicates,
+  canonical_ids = canonical_ids,
+  config = list(beta = beta, alpha = alpha, epsilon = epsilon,
+                n_activity_bins = n_activity_bins, max_age = max_age, B = B),
+  n_failed = sum(failed)
+)
+
+if (!dir.exists("data")) dir.create("data")
+saveRDS(boot_results, "data/boot_analysis_3.rds")
+message("saved data/boot_analysis_3.rds")

--- a/R/functions.R
+++ b/R/functions.R
@@ -1132,9 +1132,230 @@ autoplot_contact_matrix <- function(contact_matrix, palette = 1) {
     theme(
       axis.text = element_text(
         size = 6,
-        angle = 45, 
+        angle = 45,
         hjust = 1
       )
     )
-    
+
+}
+
+# Run the downstream "final analysis" of analysis 3 (the two-stage method) on a
+# participant-level contact dataset, returning the quantities we want bootstrap
+# intervals on: the residual heterogeneity sigma, the two R0s, and the overall
+# and by-age final sizes for the three scenarios (age matrix, age matrix
+# rescaled to the age/activity R0, and age/activity matrix). This encapsulates
+# the non-illustrative part of R/analysis_3_real_world_application.qmd so it can
+# be re-run on bootstrap resamples. `contact_data` must have columns age_from,
+# age_to, setting, contacts and part_id (as produced by process_fc_data_conmat()
+# after renaming). All other arguments are held fixed across bootstraps, since
+# they are modelling choices rather than survey data.
+fc_final_size_pipeline <- function(contact_data,
+                                   population,
+                                   beta = 0.1,
+                                   alpha = 0.5,
+                                   epsilon = 0.5,
+                                   n_activity_bins = 10,
+                                   max_age = 90) {
+
+  # --- step a: age-structured contact model (aggregated across participants) --
+  contact_data_summarised <- contact_data |>
+    group_by(age_from, age_to, setting) |>
+    summarise(contacts = sum(contacts),
+              participants = n(),
+              .groups = "drop")
+
+  model_aggregated <- fit_single_contact_model(
+    contact_data = contact_data_summarised,
+    population = population
+  )
+
+  # 5-year age matrix up to max_age, and the population fraction in each bin
+  age_breaks <- seq(0, max_age, by = 5)
+  age_contact_pred <- predict_contacts(model_aggregated,
+                                       population,
+                                       age_breaks = age_breaks)
+  age_matrix <- conmat::predictions_to_matrix(age_contact_pred)
+  pop_bin <- population |>
+    filter(lower.age.limit < max_age) |>
+    pull(population)
+  age_fractions <- pop_bin / sum(pop_bin)
+
+  # --- step b: residual between-participant SD (sigma) via a Poisson GLMM ------
+  # predict per-year contacts to use as the model offset
+  year_range <- range(c(contact_data$age_from, contact_data$age_to),
+                      na.rm = TRUE)
+  age_breaks_years <- seq(year_range[1], year_range[2] + 1, by = 1)
+  year_age_group_lookup <- tibble(age = age_breaks_years) |>
+    mutate(age_group = sprintf("[%s,%s)", age, age + 1))
+
+  age_contact_pred_years <- model_aggregated |>
+    predict_contacts(population, age_breaks = age_breaks_years) |>
+    left_join(year_age_group_lookup, by = c(age_group_from = "age_group")) |>
+    rename(age_from = age) |>
+    left_join(year_age_group_lookup, by = c(age_group_to = "age_group")) |>
+    rename(age_to = age, predicted_contacts = contacts) |>
+    select(age_from, age_to, predicted_contacts)
+
+  contact_data_modelling <- contact_data |>
+    left_join(age_contact_pred_years, by = c("age_from", "age_to")) |>
+    filter(age_from <= max_age, age_to <= max_age)
+
+  # nAGQ = 0 for numerical robustness (see the qmd for the rationale)
+  model_twostage <- lme4::glmer(
+    contacts ~ offset(log(predicted_contacts)) + (1 | part_id),
+    family = stats::poisson,
+    data = contact_data_modelling,
+    nAGQ = 0
+  )
+
+  sigma <- model_twostage |>
+    summary() |>
+    extracting("varcor") |>
+    as_tibble() |>
+    filter(grp == "part_id") |>
+    pull(sdcor)
+
+  # --- activity-structured matrix and combined age/activity matrix ------------
+  activity_matrix <- make_activity_matrix(n_activity_bins = n_activity_bins,
+                                          sigma = sigma,
+                                          alpha = alpha,
+                                          epsilon = epsilon)
+  activity_fractions <- attr(activity_matrix, "activity_bins")$fraction
+
+  age_activity_matrix <- tile_matrices(age_matrix, activity_matrix)
+  age_activity_fractions <- tile_fractions(age_fractions, activity_fractions)
+
+  # --- R0s --------------------------------------------------------------------
+  R0_age <- get_eigenval(age_matrix * beta)
+  R0_age_activity <- get_eigenval(age_activity_matrix * beta)
+
+  # --- final sizes for the three scenarios ------------------------------------
+  n_age <- length(age_fractions)
+  n_age_activity <- length(age_activity_fractions)
+  dummy_age <- as.matrix(rep(1, n_age))
+  dummy_age_activity <- as.matrix(rep(1, n_age_activity))
+
+  # rescale so that (matrix * fractions) has an eigenvalue of 1 (a requirement
+  # of final_size)
+  age_matrix_scaled <- age_matrix / get_eigenval(age_matrix * age_fractions)
+  age_activity_matrix_scaled <- age_activity_matrix /
+    get_eigenval(age_activity_matrix * age_activity_fractions)
+
+  size_age <- final_size(r0 = R0_age,
+                         contact_matrix = age_matrix_scaled,
+                         demography_vector = age_fractions,
+                         susceptibility = dummy_age,
+                         p_susceptibility = dummy_age)
+
+  size_age_scaled <- final_size(r0 = R0_age_activity,
+                                contact_matrix = age_matrix_scaled,
+                                demography_vector = age_fractions,
+                                susceptibility = dummy_age,
+                                p_susceptibility = dummy_age)
+
+  size_age_activity <- final_size(r0 = R0_age_activity,
+                                  contact_matrix = age_activity_matrix_scaled,
+                                  demography_vector = age_activity_fractions,
+                                  susceptibility = dummy_age_activity,
+                                  p_susceptibility = dummy_age_activity)
+
+  # collapse the age/activity final sizes down to age groups
+  size_age_activity_by_age <- size_age_activity |>
+    mutate(demo_grp = str_split_i(demo_grp, "-", 1)) |>
+    group_by(demo_grp) |>
+    summarise(p_infected = sum(p_infected * activity_fractions),
+              .groups = "drop")
+
+  # overall (population-weighted) final sizes
+  overall <- c(
+    age          = sum(size_age$p_infected * age_fractions),
+    age_scaled   = sum(size_age_scaled$p_infected * age_fractions),
+    age_activity = sum(size_age_activity$p_infected * age_activity_fractions)
+  )
+
+  # tidy by-age final sizes for the three scenarios, with numeric bin edges
+  parse_bins <- function(df) {
+    df |>
+      mutate(
+        age_lower = as.numeric(str_match(demo_grp, "([0-9]+)[^0-9]+([0-9]+)")[, 2]),
+        age_upper = as.numeric(str_match(demo_grp, "([0-9]+)[^0-9]+([0-9]+)")[, 3])
+      ) |>
+      select(age_lower, age_upper, p_infected)
+  }
+
+  by_age <- bind_rows(
+    age          = parse_bins(size_age),
+    age_scaled   = parse_bins(size_age_scaled),
+    age_activity = parse_bins(size_age_activity_by_age),
+    .id = "scenario"
+  ) |>
+    arrange(scenario, age_lower)
+
+  list(
+    sigma = sigma,
+    R0_age = R0_age,
+    R0_age_activity = R0_age_activity,
+    overall = overall,
+    by_age = by_age
+  )
+}
+
+# Draw a cluster (participant-level) bootstrap resample from a participant-level
+# contact dataset: sample the participants with replacement and give each drawn
+# participant a fresh unique part_id, so that a participant drawn more than once
+# is treated as distinct individuals in the (1 | part_id) random effect (rather
+# than as one participant with repeated observations, which would bias sigma
+# downward). `canonical_ids` fixes the participant ordering so the returned
+# membership indices are comparable across resamples (needed for a later BCa
+# acceleration term via jackknife-after-bootstrap). Returns the resampled data
+# and the integer indices (into canonical_ids) of the drawn participants.
+resample_participants <- function(contact_data, canonical_ids) {
+  n <- length(canonical_ids)
+  drawn_idx <- sample.int(n, size = n, replace = TRUE)
+  key <- tibble(
+    new_id = paste0("boot", seq_len(n)),
+    part_id = canonical_ids[drawn_idx]
+  )
+  resampled <- key |>
+    left_join(contact_data, by = "part_id", relationship = "many-to-many") |>
+    mutate(part_id = new_id) |>
+    select(-new_id)
+  list(data = resampled, membership = drawn_idx)
+}
+
+# Bootstrap confidence interval for a scalar quantity, returning both the plain
+# percentile interval and the bias-corrected ("BC") interval. `theta_star` is
+# the vector of bootstrap replicate estimates and `theta_hat` the point estimate
+# from the full data. The BC interval shifts the percentiles to correct for any
+# median bias between theta_hat and the bootstrap distribution, via the
+# bias-correction constant z0 = Phi^-1(fraction of replicates below theta_hat).
+# The acceleration term of a full BCa interval is set to zero here (see the
+# analysis-3 qmd for why it is deferred); z0 is returned so the size of the bias
+# correction can be inspected. Following Efron & Tibshirani (1993).
+bc_ci <- function(theta_star, theta_hat, level = 0.95) {
+  theta_star <- theta_star[is.finite(theta_star)]
+  n_star <- length(theta_star)
+  a_tail <- (1 - level) / 2
+  probs <- c(a_tail, 1 - a_tail)
+
+  # plain percentile interval
+  pct <- quantile(theta_star, probs, names = FALSE, type = 7)
+
+  # bias correction: z0 from the fraction of replicates below the point estimate
+  prop_below <- mean(theta_star < theta_hat)
+  # guard degenerate proportions (0 or 1 would give an infinite z0)
+  prop_below <- min(max(prop_below, 1 / (2 * n_star)), 1 - 1 / (2 * n_star))
+  z0 <- qnorm(prop_below)
+
+  # adjusted percentiles (acceleration a = 0)
+  adj_probs <- pnorm(2 * z0 + qnorm(probs))
+  bc <- quantile(theta_star, adj_probs, names = FALSE, type = 7)
+
+  tibble(
+    estimate = theta_hat,
+    pct_lower = pct[1], pct_upper = pct[2],
+    bc_lower = bc[1], bc_upper = bc[2],
+    z0 = z0,
+    n_boot = n_star
+  )
 }

--- a/R/functions.R
+++ b/R/functions.R
@@ -250,7 +250,76 @@ partition_variance_lmer <- function (model) {
     rename(
       partition = grp
     )
-  
+
+}
+
+# given a fitted Poisson-log GLMM that includes an observation-level random
+# effect named "obs", perform the variance partitioning on the latent (log)
+# scale. Unlike a Gaussian LMM, a Poisson-log model has no residual variance
+# parameter: the within-individual, day-to-day variation is split into (i) an
+# observation-level random effect capturing extra-Poisson (overdispersion)
+# variation, and (ii) a "distribution-specific" term for the Poisson sampling
+# variance, expressed on the log scale. Both are pooled into the "within
+# individuals" partition so the result is directly comparable to
+# partition_variance_lmer(). See Nakagawa, Johnson & Schielzeth (2017).
+partition_variance_glmer <- function (model) {
+
+  # random-effect variances, on the log (latent) scale. glmer does not report a
+  # "Residual" row for a Poisson family (the scale is fixed), but filter it out
+  # defensively in case it appears.
+  var_components <- model |>
+    summary() |>
+    extracting("varcor") |>
+    as_tibble() |>
+    filter(grp != "Residual") |>
+    select(
+      grp,
+      var = vcov
+    )
+
+  # population-mean count: lambda = exp(beta0 + 0.5 * sum of RE variances)
+  beta0 <- lme4::fixef(model)[["(Intercept)"]]
+  lambda <- exp(beta0 + 0.5 * sum(var_components$var))
+
+  # distribution-specific (Poisson sampling) variance on the log scale. The
+  # trigamma function is the most exact approximation (Nakagawa et al. 2017); the
+  # lognormal approximation log(1 + 1 / lambda) agrees to within ~1% at the
+  # moderate counts seen here.
+  var_dist <- psigamma(lambda, deriv = 1)
+  # var_dist <- log(1 + 1 / lambda)  # lognormal approximation (alternative)
+
+  var_components |>
+    # add the Poisson sampling variance as its own (within-individual) component
+    bind_rows(
+      tibble(grp = "poisson_sampling", var = var_dist)
+    ) |>
+    mutate(
+      partition = case_when(
+        grp == "part_age" ~ "between ages",
+        grp == "part_gender" ~ "between genders",
+        grp == "part_occupation" ~ "between occupations",
+        grp %in% c("obs", "poisson_sampling") ~ "within individuals",
+        .default = "between individuals (unexplained)",
+      )
+    ) |>
+    # pool the observation-level RE and Poisson sampling into "within
+    # individuals"
+    group_by(
+      partition
+    ) |>
+    summarise(
+      var = sum(var),
+      .groups = "drop"
+    ) |>
+    mutate(
+      proportion = var / sum(var)
+    ) |>
+    select(
+      partition,
+      var,
+      proportion
+    )
+
 }
 
 make_barplot <- function(partitioning) {

--- a/R/functions.R
+++ b/R/functions.R
@@ -322,18 +322,26 @@ partition_variance_glmer <- function (model) {
 
 }
 
-make_barplot <- function(partitioning) {
-  
-  # set up colour palette for bar charts
+make_barplot <- function(partitioning, drop = TRUE, label_threshold = 0.05) {
+
+  # semantic colour palette:
+  # - within individuals: light grey - the dominant component, but the one of
+  #   least significance in the downstream analyses, so de-emphasised
+  # - between individuals (unexplained): green, matching the activity-structured
+  #   contact matrix panel in analysis 3
+  # - between ages: blue, matching the age-structured contact matrix panel in
+  #   analysis 3
+  # - between genders / occupations: distinguishable shades of the age blue, as
+  #   they are largely confounded with age
   colour_palette <- c(
-    "within individuals" = "pink",
-    "between individuals (unexplained)" = scales::alpha("blue", 0.1),
-    "between genders" = scales::alpha("blue", 0.4),
-    "between ages" = scales::alpha("blue", 0.5),
-    "between occupations" =  scales::alpha("blue", 0.6)
+    "within individuals" = "grey88",
+    "between individuals (unexplained)" = "#41AE76",
+    "between ages" = "#2171B5",
+    "between genders" = "#9ECAE1",
+    "between occupations" = "#08306B"
   )
-  
-  partitioning |>
+
+  plot_data <- partitioning |>
     # set the factor order for partition to how we want to plot it
     mutate(
       partition = factor(partition,
@@ -357,28 +365,79 @@ make_barplot <- function(partitioning) {
     rename(
       `Variance explained` = proportion,
       Component = partition
-    ) |>
-    ggplot(
+    )
+
+  # split the labels: large slices are labelled inside the bar; small slices
+  # that would overlap are labelled outside with a leader line (coloured by
+  # component, so which label belongs to which slice is unambiguous)
+  labels_inside <- plot_data |>
+    filter(`Variance explained` >= label_threshold)
+  labels_outside <- plot_data |>
+    filter(`Variance explained` < label_threshold)
+  # nudge outside labels away from the bars: left for the first study, right for
+  # the rest
+  n_studies <- length(unique(plot_data$Study))
+  outside_nudge <- ifelse(
+    as.integer(factor(labels_outside$Study)) <= n_studies / 2,
+    -0.7,
+    0.7
+  )
+
+  p <- ggplot(
+      plot_data,
       aes(
         x = Study,
         y = `Variance explained`,
         fill = Component
       )
-    ) + 
+    ) +
     geom_bar(
       stat = "identity"
     ) +
     geom_text(
+      data = labels_inside,
       aes(
         label = text_percent,
         y = text_position
-      )
+      ),
+      size = 5
     ) +
     scale_y_continuous(
       labels = scales::label_percent()
     ) +
-    scale_fill_manual(values = colour_palette) +
+    # drop = FALSE keeps all components in the scale (and hence the legend) even
+    # when a panel lacks some, so legends can be combined across panels
+    scale_fill_manual(values = colour_palette, drop = drop) +
+    # matched colour scale for the leader-line labels (no separate legend)
+    scale_colour_manual(values = colour_palette, guide = "none") +
     theme_minimal()
+
+  # only add the leader-line layer (and the extra horizontal room it needs) when
+  # there are small slices to label this way
+  if (nrow(labels_outside) > 0) {
+    p <- p +
+      ggrepel::geom_text_repel(
+        data = labels_outside,
+        aes(
+          label = text_percent,
+          y = text_position,
+          colour = Component
+        ),
+        nudge_x = outside_nudge,
+        direction = "y",
+        hjust = 0,
+        size = 4,
+        min.segment.length = 0,
+        segment.colour = "black",
+        segment.size = 0.25,
+        box.padding = 0.3,
+        show.legend = FALSE,
+        seed = 2026
+      ) +
+      scale_x_discrete(expand = expansion(add = 0.9))
+  }
+
+  p
 }
 
 # load the various French Connection datasets

--- a/R/functions.R
+++ b/R/functions.R
@@ -604,11 +604,7 @@ bin_mean_activity <- function(lower, upper, sigma) {
 # activity level per bin
 quantile2_classes_mean <- function(sigma,
                                    n_classes,
-                                   alpha = 1e-5) {
-  
-  # upper limit for integration
-  max_quantile <- 1 - alpha
-  # max_activity <- qlnorm(max_quantile, meanlog = 0, sdlog = sigma)
+                                   max_quantile = 1 - 1e-5) {
   
   # define quantiles and get lower and upper bounds of the bins
   probs <- seq(0, max_quantile, length.out = n_classes + 1)

--- a/R/functions.R
+++ b/R/functions.R
@@ -322,6 +322,18 @@ partition_variance_glmer <- function (model) {
 
 }
 
+# format a proportion (0-1) as a percentage label: to the nearest integer, but
+# to a single decimal place when it would otherwise round to 0%, and "<0.1%"
+# when even one decimal place would round to 0
+format_percent_label <- function(proportion) {
+  pct <- 100 * proportion
+  case_when(
+    round(pct) >= 1 ~ sprintf("%.0f%%", pct),
+    round(pct, 1) >= 0.1 ~ sprintf("%.1f%%", pct),
+    .default = "<0.1%"
+  )
+}
+
 make_barplot <- function(partitioning, drop = TRUE, label_threshold = 0.05) {
 
   # semantic colour palette:
@@ -357,7 +369,7 @@ make_barplot <- function(partitioning, drop = TRUE, label_threshold = 0.05) {
     ) |>
     # for labels
     mutate(
-      text_percent = scales::label_percent()(proportion),
+      text_percent = format_percent_label(proportion),
       text_position = rev(cumsum(rev(proportion))) - proportion / 2
     ) |>
     ungroup() |>
@@ -377,11 +389,17 @@ make_barplot <- function(partitioning, drop = TRUE, label_threshold = 0.05) {
   # nudge outside labels away from the bars: left for the first study, right for
   # the rest
   n_studies <- length(unique(plot_data$Study))
+  # sit the labels tight against the outer edge of each bar: nudge just far
+  # enough to clear the bar
   outside_nudge <- ifelse(
     as.integer(factor(labels_outside$Study)) <= n_studies / 2,
-    -0.7,
-    0.7
+    -0.5,
+    0.5
   )
+  # align labels to the bar edge: the first (left-hand) study's labels are
+  # right-aligned (right edge against the bar, text into the margin), the rest
+  # left-aligned (left edge against the bar)
+  outside_hjust <- ifelse(outside_nudge < 0, 1, 0)
 
   p <- ggplot(
       plot_data,
@@ -400,16 +418,17 @@ make_barplot <- function(partitioning, drop = TRUE, label_threshold = 0.05) {
         label = text_percent,
         y = text_position
       ),
-      size = 5
+      size = 4
     ) +
     scale_y_continuous(
-      labels = scales::label_percent()
+      labels = scales::label_percent(accuracy = 1)
     ) +
     # drop = FALSE keeps all components in the scale (and hence the legend) even
     # when a panel lacks some, so legends can be combined across panels
     scale_fill_manual(values = colour_palette, drop = drop) +
     # matched colour scale for the leader-line labels (no separate legend)
     scale_colour_manual(values = colour_palette, guide = "none") +
+    xlab(NULL) +
     theme_minimal()
 
   # only add the leader-line layer (and the extra horizontal room it needs) when
@@ -425,16 +444,17 @@ make_barplot <- function(partitioning, drop = TRUE, label_threshold = 0.05) {
         ),
         nudge_x = outside_nudge,
         direction = "y",
-        hjust = 0,
+        hjust = outside_hjust,
         size = 4,
         min.segment.length = 0,
         segment.colour = "black",
         segment.size = 0.25,
-        box.padding = 0.3,
+        box.padding = 0.1,
         show.legend = FALSE,
         seed = 2026
       ) +
-      scale_x_discrete(expand = expansion(add = 0.9))
+      # just enough horizontal room for the label text to sit beside the bars
+      scale_x_discrete(expand = expansion(add = 1))
   }
 
   p

--- a/R/functions.R
+++ b/R/functions.R
@@ -334,6 +334,13 @@ format_percent_label <- function(proportion) {
   )
 }
 
+# as format_percent_label() but always to one decimal place (used in the tables,
+# where there is room for the extra precision); still "<0.1%" below 0.05%
+format_percent_label_1dp <- function(proportion) {
+  pct <- 100 * proportion
+  ifelse(round(pct, 1) >= 0.1, sprintf("%.1f%%", pct), "<0.1%")
+}
+
 make_barplot <- function(partitioning, drop = TRUE, label_threshold = 0.05) {
 
   # semantic colour palette:

--- a/R/packages.R
+++ b/R/packages.R
@@ -2,6 +2,7 @@
 
 library(tidyverse)
 library(patchwork)
+library(ggrepel)
 library(usedist)
 library(cowplot)
 library(conmat)  # remotes::install_github("goldingn/conmat@heterogeneous-augmentation")

--- a/R/vis_quadrature.R
+++ b/R/vis_quadrature.R
@@ -1,5 +1,7 @@
 # Visualise the quadrature rules
 library(tidyverse)
+source("R/packages.R")
+source("R/functions.R")
 
 sigma <- 0.4
 n_int <- 7


### PR DESCRIPTION
Don't merge yet, more stuff coming.

Merging this PR will:

- Update analysis 1 (variance partitioning)
  - Perform variance partitioning with a poisson sampling distribution, matching the later model
  - Handle overdispersion with an observation-level random effect and map poisson sampling noise to log scale following [Nakagawa, Johnson & Schielzeth (2017)](https://doi.org/10.1098/rsif.2017.0213)
  - update the variance partitioning figure into a single multipanel with semantic colours (matching analysis 3 matrices) and labels
  - output tables of variance partitions

- Update analysis 3 (eigenvalues and final attack rates with and without activity matrix):
  - save all plots to disk, to easily upload to Overleaf
  - make deterministic (imputation of contact ages was stochastic), and fix numerical instability in inference by:
    1.  capping contacts to below age 90 before running conmat
    2. fitting the sigma GLMM with nAGQ=0 (confirming it gives near-identical results compared with seeds where it runs) 
  - tidy up the final attack rate figure
  - implement bootstrap confidence intervals and add to final attack rate figure

- Update analysis S1 (Gaussian quadrature experiments)
  - tidy up text for S1 to remove redundant results (Monte Carlo approximation of true eigenvalue)
  - bring over visualisation of integration schemes
  - make publication-quality plots of numerical experiments